### PR TITLE
Fix issue with hardcoded local to en_US

### DIFF
--- a/lib/src/linked_in_user_model.dart
+++ b/lib/src/linked_in_user_model.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/cupertino.dart';
 import 'package:linkedin_login/src/linked_in_auth_response_wrapper.dart';
 
 class LinkedInUserModel {
@@ -68,7 +69,7 @@ class _LinkedInLocalInfo {
 
   factory _LinkedInLocalInfo.fromJson(Map<String, dynamic> json) =>
       _LinkedInLocalInfo(
-        label: json.values.toList()[0], // possible error
+        label: getFirstInListFromJson(json),
       );
 
   static _LinkedInLocalInfo parseUser(String responseBody) {
@@ -76,6 +77,22 @@ class _LinkedInLocalInfo {
 
     return _LinkedInLocalInfo.fromJson(parsed);
   }
+}
+
+/// Helper function to parse first element from json
+/// If there is no element, or element is not string it will return you null
+@visibleForTesting
+String getFirstInListFromJson(Map<String, dynamic> json) {
+  final jsonValue = json?.values;
+
+  if (jsonValue != null && jsonValue.isNotEmpty) {
+    final jsonLocalization = jsonValue.toList().first;
+    if (jsonLocalization is String) {
+      return jsonLocalization;
+    }
+  }
+
+  return null;
 }
 
 class _LinkedInPreferredLocal {

--- a/lib/src/linked_in_user_model.dart
+++ b/lib/src/linked_in_user_model.dart
@@ -68,7 +68,7 @@ class _LinkedInLocalInfo {
 
   factory _LinkedInLocalInfo.fromJson(Map<String, dynamic> json) =>
       _LinkedInLocalInfo(
-        label: json['en_US'], // possible error
+        label: json.values.toList()[0], // possible error
       );
 
   static _LinkedInLocalInfo parseUser(String responseBody) {

--- a/test/unit/src/linked_in_user_model_test.dart
+++ b/test/unit/src/linked_in_user_model_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../lib/src/linked_in_user_model.dart';
+
+void main() {
+  group('Tests for _getFirstInListFromJson method', () {
+    test('If json is null, return null', () {
+      expect(getFirstInListFromJson(null), null);
+    });
+
+    test('If json is empty, return null', () {
+      expect(getFirstInListFromJson({}), null);
+    });
+
+    test('If json is contains int type as value, return null', () {
+      expect(getFirstInListFromJson({"local": 23}), null);
+    });
+
+    test('If json is contains English local, return the en_US code', () {
+      expect(getFirstInListFromJson({"local": "en_US"}), "en_US");
+    });
+
+    test('If json is contains Spanish local, return the es_ES code', () {
+      expect(getFirstInListFromJson({"local": "es_ES"}), "es_ES");
+    });
+  });
+}


### PR DESCRIPTION
 _LinkedInLocalInfo updated getting the first value of json map, avoiding error if user has no en_US name.