### PR TITLE
Configurable button container background color

### DIFF
--- a/lib/src/utils/widgets/linked_in_buttons.dart
+++ b/lib/src/utils/widgets/linked_in_buttons.dart
@@ -14,6 +14,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
     this.iconAssetPath = 'assets/linked_in_logo.png',
     this.buttonText = 'Sign in with LinkedIn',
     this.buttonColor = Colors.white,
+    this.bgColor = Colors.blue,
     this.textPadding = const EdgeInsets.all(4),
     final Key? key,
   }) : super(key: key);
@@ -24,6 +25,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
   final String iconAssetPath;
   final String buttonText;
   final Color buttonColor;
+  final Color bgColor;
   final EdgeInsets textPadding;
 
   @override
@@ -31,7 +33,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
         child: InkWell(
           onTap: onTap as void Function()?,
           child: Container(
-            color: Colors.blue,
+            color: bgColor,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
@@ -44,7 +46,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
                 ),
                 Container(
                   padding: textPadding,
-                  color: Colors.blue,
+                  color: bgColor,
                   child: Text(
                     buttonText,
                     style: TextStyle(

--- a/lib/src/utils/widgets/linked_in_buttons.dart
+++ b/lib/src/utils/widgets/linked_in_buttons.dart
@@ -14,7 +14,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
     this.iconAssetPath = 'assets/linked_in_logo.png',
     this.buttonText = 'Sign in with LinkedIn',
     this.buttonColor = Colors.white,
-    this.bgColor = Colors.blue,
+    this.backgroundColor = Colors.blue,
     this.textPadding = const EdgeInsets.all(4),
     final Key? key,
   }) : super(key: key);
@@ -25,7 +25,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
   final String iconAssetPath;
   final String buttonText;
   final Color buttonColor;
-  final Color bgColor;
+  final Color backgroundColor;
   final EdgeInsets textPadding;
 
   @override
@@ -33,7 +33,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
         child: InkWell(
           onTap: onTap as void Function()?,
           child: Container(
-            color: bgColor,
+            color: backgroundColor,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
@@ -46,7 +46,7 @@ class LinkedInButtonStandardWidget extends StatelessWidget {
                 ),
                 Container(
                   padding: textPadding,
-                  color: bgColor,
+                  color: backgroundColor,
                   child: Text(
                     buttonText,
                     style: TextStyle(


### PR DESCRIPTION
Adds a user configurable way to define the background color of the widget container. This leaves the default Colors.blue, but allows the user to set whatever background color they want, in our case Colors.transparent since we just use the icon with no text.

Fixes variable naming issue mentioned in https://github.com/d3xt3r2909/linkedin_login/pull/74. Unfortunately I missed the comment, so I'm opening a new pull request with the requested changes.