### PR TITLE
Option to add custom scope

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,7 +89,7 @@ class _LinkedInProfileExamplePageState
                       ProjectionParameters.lastName,
                       ProjectionParameters.profilePicture,
                     ],
-                    scope: const ['r_emailaddress', 'r_liteprofile'],
+                    scope: const [EmailAddressScope(), LiteProfileScope()],
                     onError: (final UserFailedAction e) {
                       print('Error: ${e.toString()}');
                       print('Error: ${e.stackTrace.toString()}');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,6 +89,7 @@ class _LinkedInProfileExamplePageState
                       ProjectionParameters.lastName,
                       ProjectionParameters.profilePicture,
                     ],
+                    scope: const ['r_emailaddress', 'r_liteprofile'],
                     onError: (final UserFailedAction e) {
                       print('Error: ${e.toString()}');
                       print('Error: ${e.stackTrace.toString()}');

--- a/lib/linkedin_login.dart
+++ b/lib/linkedin_login.dart
@@ -5,6 +5,7 @@ export 'package:linkedin_login/src/client/linked_in_user_widget.dart';
 export 'package:linkedin_login/src/model/linked_in_user_model.dart';
 export 'package:linkedin_login/src/server/linked_in_auth_code_widget.dart';
 export 'package:linkedin_login/src/utils/constants.dart';
+export 'package:linkedin_login/src/utils/scope.dart';
 export 'package:linkedin_login/src/utils/widgets/linked_in_buttons.dart';
 export 'package:linkedin_login/src/wrappers/authorization_code_response.dart';
 export 'package:linkedin_login/src/wrappers/linked_in_token_object.dart';

--- a/lib/src/client/linked_in_user_widget.dart
+++ b/lib/src/client/linked_in_user_widget.dart
@@ -32,6 +32,7 @@ class LinkedInUserWidget extends StatefulWidget {
       ProjectionParameters.lastName,
     ],
     this.useVirtualDisplay = false,
+    this.scope,
     final Key? key,
   })  : assert(projection.isNotEmpty),
         super(key: key);
@@ -45,6 +46,7 @@ class LinkedInUserWidget extends StatefulWidget {
   final bool destroySession;
   final List<String> projection;
   final bool useVirtualDisplay;
+  final List<String>? scope;
 
   @override
   State createState() => _LinkedInUserWidgetState();
@@ -67,6 +69,7 @@ class _LinkedInUserWidgetState extends State<LinkedInUserWidget> {
         clientIdParam: widget.clientId,
         redirectUrlParam: widget.redirectUrl,
         urlState: const Uuid().v4(),
+        scopeParam: widget.scope,
       ),
     );
 

--- a/lib/src/client/linked_in_user_widget.dart
+++ b/lib/src/client/linked_in_user_widget.dart
@@ -32,7 +32,10 @@ class LinkedInUserWidget extends StatefulWidget {
       ProjectionParameters.lastName,
     ],
     this.useVirtualDisplay = false,
-    this.scope,
+    this.scope = const [
+      'r_liteprofile',
+      'r_emailaddress',
+    ],
     final Key? key,
   })  : assert(projection.isNotEmpty),
         super(key: key);
@@ -46,7 +49,7 @@ class LinkedInUserWidget extends StatefulWidget {
   final bool destroySession;
   final List<String> projection;
   final bool useVirtualDisplay;
-  final List<String>? scope;
+  final List<String> scope;
 
   @override
   State createState() => _LinkedInUserWidgetState();

--- a/lib/src/client/linked_in_user_widget.dart
+++ b/lib/src/client/linked_in_user_widget.dart
@@ -3,6 +3,7 @@ import 'package:linkedin_login/src/actions.dart';
 import 'package:linkedin_login/src/client/fetcher.dart';
 import 'package:linkedin_login/src/utils/configuration.dart';
 import 'package:linkedin_login/src/utils/constants.dart';
+import 'package:linkedin_login/src/utils/scope.dart';
 import 'package:linkedin_login/src/utils/startup/graph.dart';
 import 'package:linkedin_login/src/utils/startup/initializer.dart';
 import 'package:linkedin_login/src/utils/startup/injector.dart';
@@ -33,8 +34,8 @@ class LinkedInUserWidget extends StatefulWidget {
     ],
     this.useVirtualDisplay = false,
     this.scope = const [
-      'r_liteprofile',
-      'r_emailaddress',
+      LiteProfileScope(),
+      EmailAddressScope(),
     ],
     final Key? key,
   })  : assert(projection.isNotEmpty),
@@ -49,7 +50,7 @@ class LinkedInUserWidget extends StatefulWidget {
   final bool destroySession;
   final List<String> projection;
   final bool useVirtualDisplay;
-  final List<String> scope;
+  final List<Scope> scope;
 
   @override
   State createState() => _LinkedInUserWidgetState();

--- a/lib/src/server/linked_in_auth_code_widget.dart
+++ b/lib/src/server/linked_in_auth_code_widget.dart
@@ -23,7 +23,10 @@ class LinkedInAuthCodeWidget extends StatefulWidget {
     this.frontendRedirectUrl,
     this.appBar,
     this.useVirtualDisplay = false,
-    this.scope,
+    this.scope = const [
+      'r_liteprofile',
+      'r_emailaddress',
+    ],
     final Key? key,
   }) : super(key: key);
 
@@ -34,7 +37,7 @@ class LinkedInAuthCodeWidget extends StatefulWidget {
   final AppBar? appBar;
   final bool destroySession;
   final bool useVirtualDisplay;
-  final List<String>? scope;
+  final List<String> scope;
 
   // just in case that frontend in your team has changed redirect url
   final String? frontendRedirectUrl;

--- a/lib/src/server/linked_in_auth_code_widget.dart
+++ b/lib/src/server/linked_in_auth_code_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:linkedin_login/src/actions.dart';
 import 'package:linkedin_login/src/server/fetcher.dart';
 import 'package:linkedin_login/src/utils/configuration.dart';
+import 'package:linkedin_login/src/utils/scope.dart';
 import 'package:linkedin_login/src/utils/startup/graph.dart';
 import 'package:linkedin_login/src/utils/startup/initializer.dart';
 import 'package:linkedin_login/src/utils/startup/injector.dart';
@@ -24,8 +25,8 @@ class LinkedInAuthCodeWidget extends StatefulWidget {
     this.appBar,
     this.useVirtualDisplay = false,
     this.scope = const [
-      'r_liteprofile',
-      'r_emailaddress',
+      LiteProfileScope(),
+      EmailAddressScope(),
     ],
     final Key? key,
   }) : super(key: key);
@@ -37,7 +38,7 @@ class LinkedInAuthCodeWidget extends StatefulWidget {
   final AppBar? appBar;
   final bool destroySession;
   final bool useVirtualDisplay;
-  final List<String> scope;
+  final List<Scope> scope;
 
   // just in case that frontend in your team has changed redirect url
   final String? frontendRedirectUrl;

--- a/lib/src/server/linked_in_auth_code_widget.dart
+++ b/lib/src/server/linked_in_auth_code_widget.dart
@@ -23,6 +23,7 @@ class LinkedInAuthCodeWidget extends StatefulWidget {
     this.frontendRedirectUrl,
     this.appBar,
     this.useVirtualDisplay = false,
+    this.scope,
     final Key? key,
   }) : super(key: key);
 
@@ -33,6 +34,7 @@ class LinkedInAuthCodeWidget extends StatefulWidget {
   final AppBar? appBar;
   final bool destroySession;
   final bool useVirtualDisplay;
+  final List<String>? scope;
 
   // just in case that frontend in your team has changed redirect url
   final String? frontendRedirectUrl;
@@ -54,6 +56,7 @@ class _LinkedInAuthCodeWidgetState extends State<LinkedInAuthCodeWidget> {
         redirectUrlParam: widget.redirectUrl,
         clientIdParam: widget.clientId,
         frontendRedirectUrlParam: widget.frontendRedirectUrl,
+        scopeParam: widget.scope,
       ),
     );
   }

--- a/lib/src/utils/configuration.dart
+++ b/lib/src/utils/configuration.dart
@@ -11,14 +11,14 @@ abstract class Config {
 
   String get state;
 
-  List<String>? get scope;
-
   String get initialUrl;
+
+  String scope(final List<String> list) => list.join('%20');
 
   bool isCurrentUrlMatchToRedirection(final String url);
 }
 
-class AccessCodeConfiguration implements Config {
+class AccessCodeConfiguration extends Config {
   AccessCodeConfiguration({
     required this.redirectUrlParam,
     required this.clientIdParam,
@@ -33,7 +33,7 @@ class AccessCodeConfiguration implements Config {
   final String? redirectUrlParam;
   final String? clientIdParam;
   final String urlState;
-  final List<String>? scopeParam;
+  final List<String> scopeParam;
 
   @override
   String? get clientId => clientIdParam;
@@ -54,15 +54,12 @@ class AccessCodeConfiguration implements Config {
   String get state => urlState;
 
   @override
-  List<String>? get scope => scopeParam;
-
-  @override
   String get initialUrl => 'https://www.linkedin.com/oauth/v2/authorization?'
       'response_type=code'
       '&client_id=$clientId'
       '&state=$urlState'
       '&redirect_uri=$redirectUrl'
-      '&scope=${scope?.join('%20') ?? 'r_liteprofile%20r_emailaddress'}';
+      '&scope=${scope(scopeParam)}';
 
   @override
   bool isCurrentUrlMatchToRedirection(final String url) =>
@@ -79,11 +76,11 @@ class AccessCodeConfiguration implements Config {
         'projectionParam: $projectionParam,'
         ' redirectUrlParam: $redirectUrlParam,'
         ' clientIdParam: $clientIdParam, urlState: $urlState}, '
-        'scope:$scopeParam';
+        'scope:${scope(scopeParam)}';
   }
 }
 
-class AuthCodeConfiguration implements Config {
+class AuthCodeConfiguration extends Config {
   AuthCodeConfiguration({
     required this.redirectUrlParam,
     required this.clientIdParam,
@@ -96,7 +93,7 @@ class AuthCodeConfiguration implements Config {
   final String? clientIdParam;
   final String? frontendRedirectUrlParam;
   final String urlState;
-  final List<String>? scopeParam;
+  final List<String> scopeParam;
 
   @override
   String? get clientId => clientIdParam;
@@ -117,15 +114,12 @@ class AuthCodeConfiguration implements Config {
   String get state => urlState;
 
   @override
-  List<String>? get scope => scopeParam;
-
-  @override
   String get initialUrl => 'https://www.linkedin.com/oauth/v2/authorization?'
       'response_type=code'
       '&client_id=$clientId'
       '&state=$state'
       '&redirect_uri=$redirectUrl'
-      '&scope=${scope?.join('%20') ?? 'r_liteprofile%20r_emailaddress'}';
+      '&scope=${scope(scopeParam)}';
 
   @override
   bool isCurrentUrlMatchToRedirection(final String url) =>

--- a/lib/src/utils/configuration.dart
+++ b/lib/src/utils/configuration.dart
@@ -1,3 +1,5 @@
+import 'package:linkedin_login/src/utils/scope.dart';
+
 abstract class Config {
   String? get clientSecret;
 
@@ -13,7 +15,8 @@ abstract class Config {
 
   String get initialUrl;
 
-  String scope(final List<String> list) => list.join('%20');
+  String parseScopesToQueryParam(final List<Scope> scopes) =>
+      scopes.map((final e) => e.permission).join('%20');
 
   bool isCurrentUrlMatchToRedirection(final String url);
 }
@@ -33,7 +36,7 @@ class AccessCodeConfiguration extends Config {
   final String? redirectUrlParam;
   final String? clientIdParam;
   final String urlState;
-  final List<String> scopeParam;
+  final List<Scope> scopeParam;
 
   @override
   String? get clientId => clientIdParam;
@@ -59,7 +62,7 @@ class AccessCodeConfiguration extends Config {
       '&client_id=$clientId'
       '&state=$urlState'
       '&redirect_uri=$redirectUrl'
-      '&scope=${scope(scopeParam)}';
+      '&scope=${parseScopesToQueryParam(scopeParam)}';
 
   @override
   bool isCurrentUrlMatchToRedirection(final String url) =>
@@ -76,7 +79,7 @@ class AccessCodeConfiguration extends Config {
         'projectionParam: $projectionParam,'
         ' redirectUrlParam: $redirectUrlParam,'
         ' clientIdParam: $clientIdParam, urlState: $urlState}, '
-        'scope:${scope(scopeParam)}';
+        'scope:${parseScopesToQueryParam(scopeParam)}';
   }
 }
 
@@ -93,7 +96,7 @@ class AuthCodeConfiguration extends Config {
   final String? clientIdParam;
   final String? frontendRedirectUrlParam;
   final String urlState;
-  final List<String> scopeParam;
+  final List<Scope> scopeParam;
 
   @override
   String? get clientId => clientIdParam;
@@ -119,7 +122,7 @@ class AuthCodeConfiguration extends Config {
       '&client_id=$clientId'
       '&state=$state'
       '&redirect_uri=$redirectUrl'
-      '&scope=${scope(scopeParam)}';
+      '&scope=${parseScopesToQueryParam(scopeParam)}';
 
   @override
   bool isCurrentUrlMatchToRedirection(final String url) =>

--- a/lib/src/utils/configuration.dart
+++ b/lib/src/utils/configuration.dart
@@ -11,6 +11,8 @@ abstract class Config {
 
   String get state;
 
+  List<String>? get scope;
+
   String get initialUrl;
 
   bool isCurrentUrlMatchToRedirection(final String url);
@@ -23,6 +25,7 @@ class AccessCodeConfiguration implements Config {
     required this.clientSecretParam,
     required this.projectionParam,
     required this.urlState,
+    required this.scopeParam,
   });
 
   final String? clientSecretParam;
@@ -30,6 +33,7 @@ class AccessCodeConfiguration implements Config {
   final String? redirectUrlParam;
   final String? clientIdParam;
   final String urlState;
+  final List<String>? scopeParam;
 
   @override
   String? get clientId => clientIdParam;
@@ -50,12 +54,15 @@ class AccessCodeConfiguration implements Config {
   String get state => urlState;
 
   @override
+  List<String>? get scope => scopeParam;
+
+  @override
   String get initialUrl => 'https://www.linkedin.com/oauth/v2/authorization?'
       'response_type=code'
       '&client_id=$clientId'
       '&state=$urlState'
       '&redirect_uri=$redirectUrl'
-      '&scope=r_liteprofile%20r_emailaddress';
+      '&scope=${scope?.join('%20') ?? 'r_liteprofile%20r_emailaddress'}';
 
   @override
   bool isCurrentUrlMatchToRedirection(final String url) =>
@@ -71,7 +78,8 @@ class AccessCodeConfiguration implements Config {
         '${clientSecretParam!.isNotEmpty ? 'XXX' : 'INVALID'}, '
         'projectionParam: $projectionParam,'
         ' redirectUrlParam: $redirectUrlParam,'
-        ' clientIdParam: $clientIdParam, urlState: $urlState}';
+        ' clientIdParam: $clientIdParam, urlState: $urlState}, '
+        'scope:$scopeParam';
   }
 }
 
@@ -80,6 +88,7 @@ class AuthCodeConfiguration implements Config {
     required this.redirectUrlParam,
     required this.clientIdParam,
     required this.urlState,
+    required this.scopeParam,
     this.frontendRedirectUrlParam,
   });
 
@@ -87,6 +96,7 @@ class AuthCodeConfiguration implements Config {
   final String? clientIdParam;
   final String? frontendRedirectUrlParam;
   final String urlState;
+  final List<String>? scopeParam;
 
   @override
   String? get clientId => clientIdParam;
@@ -107,12 +117,15 @@ class AuthCodeConfiguration implements Config {
   String get state => urlState;
 
   @override
+  List<String>? get scope => scopeParam;
+
+  @override
   String get initialUrl => 'https://www.linkedin.com/oauth/v2/authorization?'
       'response_type=code'
       '&client_id=$clientId'
       '&state=$state'
       '&redirect_uri=$redirectUrl'
-      '&scope=r_liteprofile%20r_emailaddress';
+      '&scope=${scope?.join('%20') ?? 'r_liteprofile%20r_emailaddress'}';
 
   @override
   bool isCurrentUrlMatchToRedirection(final String url) =>

--- a/lib/src/utils/scope.dart
+++ b/lib/src/utils/scope.dart
@@ -1,0 +1,20 @@
+abstract class Scope {
+  const Scope(this.permission);
+
+  final String permission;
+
+  @override
+  String toString() => permission;
+}
+
+class EmailAddressScope extends Scope {
+  const EmailAddressScope() : super('r_emailaddress');
+}
+
+class LiteProfileScope extends Scope {
+  const LiteProfileScope() : super('r_liteprofile');
+}
+
+class MemberSocialScope extends Scope {
+  const MemberSocialScope() : super('w_member_social');
+}

--- a/test/unit/src/utils/configuration_test.dart
+++ b/test/unit/src/utils/configuration_test.dart
@@ -16,26 +16,7 @@ void main() {
       expect(config.frontendRedirectUrl, isNull);
     });
 
-    test(
-        'initial URL should use parameters from config when scope is '
-        'not existing', () {
-      final config = AccessCodeConfiguration(
-        redirectUrlParam: 'https://www.app.dexter.com',
-        clientIdParam: 'clientIdParam',
-        urlState: 'urlState',
-        clientSecretParam: 'clientSecretParam',
-        projectionParam: const ['projection'],
-        scopeParam: null,
-      );
-
-      expect(
-        config.initialUrl,
-        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=r_liteprofile%20r_emailaddress',
-      );
-    });
-
-    test('initial URL should use parameters from config when scope is existing',
-        () {
+    test('initial URL should use parameters from config', () {
       final config = AccessCodeConfiguration(
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
@@ -134,25 +115,7 @@ void main() {
       expect(config.projection, isNull);
     });
 
-    test(
-        'initial URL should use parameters from config when scope are not '
-        'existing', () {
-      final config = AuthCodeConfiguration(
-        redirectUrlParam: 'https://www.app.dexter.com',
-        clientIdParam: 'clientIdParam',
-        urlState: 'urlState',
-        scopeParam: null,
-      );
-
-      expect(
-        config.initialUrl,
-        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=r_liteprofile%20r_emailaddress',
-      );
-    });
-
-    test(
-        'initial URL should use parameters from config when scope are '
-        'existing', () {
+    test('initial URL should use parameters from config', () {
       final config = AuthCodeConfiguration(
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',

--- a/test/unit/src/utils/configuration_test.dart
+++ b/test/unit/src/utils/configuration_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linkedin_login/src/utils/configuration.dart';
+import 'package:linkedin_login/src/utils/scope.dart';
 
 void main() {
   group('AccessCodeConfiguration class', () {
@@ -10,7 +11,7 @@ void main() {
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(config.frontendRedirectUrl, isNull);
@@ -23,12 +24,12 @@ void main() {
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
-        scopeParam: const ['scope1', 'scope2'],
+        scopeParam: const [EmailAddressScope(), LiteProfileScope()],
       );
 
       expect(
         config.initialUrl,
-        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=scope1%20scope2',
+        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=r_emailaddress%20r_liteprofile',
       );
     });
 
@@ -39,7 +40,7 @@ void main() {
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
-        scopeParam: const ['scope1'],
+        scopeParam: const [LiteProfileScope()],
       );
 
       expect(
@@ -57,7 +58,7 @@ void main() {
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(
@@ -75,7 +76,7 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(config.frontendRedirectUrl, isNull);
@@ -87,7 +88,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
         frontendRedirectUrlParam: 'frontendRedirectUrlParam',
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(config.frontendRedirectUrl, 'frontendRedirectUrlParam');
@@ -98,7 +99,7 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(config.frontendRedirectUrl, isNull);
@@ -109,7 +110,7 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(config.projection, isNull);
@@ -120,12 +121,12 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
-        scopeParam: const ['scope1', 'scope2'],
+        scopeParam: const [EmailAddressScope(), LiteProfileScope()],
       );
 
       expect(
         config.initialUrl,
-        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=scope1%20scope2',
+        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=r_emailaddress%20r_liteprofile',
       );
     });
 
@@ -136,7 +137,7 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(
@@ -155,7 +156,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
         frontendRedirectUrlParam: 'https://www.frontend.com',
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(
@@ -172,7 +173,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
         frontendRedirectUrlParam: 'https://www.frontend.com',
-        scopeParam: const ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       );
 
       expect(

--- a/test/unit/src/utils/configuration_test.dart
+++ b/test/unit/src/utils/configuration_test.dart
@@ -10,23 +10,44 @@ void main() {
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
+        scopeParam: const ['scope1'],
       );
 
       expect(config.frontendRedirectUrl, isNull);
     });
 
-    test('initial URL should use parameters from config', () {
+    test(
+        'initial URL should use parameters from config when scope is '
+        'not existing', () {
       final config = AccessCodeConfiguration(
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
+        scopeParam: null,
       );
 
       expect(
         config.initialUrl,
         'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=r_liteprofile%20r_emailaddress',
+      );
+    });
+
+    test('initial URL should use parameters from config when scope is existing',
+        () {
+      final config = AccessCodeConfiguration(
+        redirectUrlParam: 'https://www.app.dexter.com',
+        clientIdParam: 'clientIdParam',
+        urlState: 'urlState',
+        clientSecretParam: 'clientSecretParam',
+        projectionParam: const ['projection'],
+        scopeParam: const ['scope1', 'scope2'],
+      );
+
+      expect(
+        config.initialUrl,
+        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=scope1%20scope2',
       );
     });
 
@@ -37,6 +58,7 @@ void main() {
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
+        scopeParam: const ['scope1'],
       );
 
       expect(
@@ -54,6 +76,7 @@ void main() {
         urlState: 'urlState',
         clientSecretParam: 'clientSecretParam',
         projectionParam: const ['projection'],
+        scopeParam: const ['scope1'],
       );
 
       expect(
@@ -71,6 +94,7 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
+        scopeParam: const ['scope1'],
       );
 
       expect(config.frontendRedirectUrl, isNull);
@@ -82,6 +106,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
         frontendRedirectUrlParam: 'frontendRedirectUrlParam',
+        scopeParam: const ['scope1'],
       );
 
       expect(config.frontendRedirectUrl, 'frontendRedirectUrlParam');
@@ -92,6 +117,7 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
+        scopeParam: const ['scope1'],
       );
 
       expect(config.frontendRedirectUrl, isNull);
@@ -102,21 +128,41 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
+        scopeParam: const ['scope1'],
       );
 
       expect(config.projection, isNull);
     });
 
-    test('initial URL should use parameters from config', () {
+    test(
+        'initial URL should use parameters from config when scope are not '
+        'existing', () {
       final config = AuthCodeConfiguration(
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
+        scopeParam: null,
       );
 
       expect(
         config.initialUrl,
         'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=r_liteprofile%20r_emailaddress',
+      );
+    });
+
+    test(
+        'initial URL should use parameters from config when scope are '
+        'existing', () {
+      final config = AuthCodeConfiguration(
+        redirectUrlParam: 'https://www.app.dexter.com',
+        clientIdParam: 'clientIdParam',
+        urlState: 'urlState',
+        scopeParam: const ['scope1', 'scope2'],
+      );
+
+      expect(
+        config.initialUrl,
+        'https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=clientIdParam&state=urlState&redirect_uri=https://www.app.dexter.com&scope=scope1%20scope2',
       );
     });
 
@@ -127,6 +173,7 @@ void main() {
         redirectUrlParam: 'https://www.app.dexter.com',
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
+        scopeParam: const ['scope1'],
       );
 
       expect(
@@ -145,6 +192,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
         frontendRedirectUrlParam: 'https://www.frontend.com',
+        scopeParam: const ['scope1'],
       );
 
       expect(
@@ -161,6 +209,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         urlState: 'urlState',
         frontendRedirectUrlParam: 'https://www.frontend.com',
+        scopeParam: const ['scope1'],
       );
 
       expect(

--- a/test/unit/src/utils/startup/initializer_test.dart
+++ b/test/unit/src/utils/startup/initializer_test.dart
@@ -24,7 +24,10 @@ void main() {
     expect(graph.linkedInConfiguration.frontendRedirectUrl, isNull);
     expect(graph.linkedInConfiguration.state, 'urlState');
     expect(graph.linkedInConfiguration.projection!.length, 5);
-    expect(graph.linkedInConfiguration.scope!.length, 2);
+    expect(
+      graph.linkedInConfiguration.scope(['scope1', 'scope2']),
+      'scope1%20scope2',
+    );
   });
 
   test('is graph created with init for AuthCodeConfig', () async {
@@ -48,6 +51,6 @@ void main() {
     );
     expect(graph.linkedInConfiguration.projection, isNull);
     expect(graph.linkedInConfiguration.clientSecret, isNull);
-    expect(graph.linkedInConfiguration.scope!.length, 1);
+    expect(graph.linkedInConfiguration.scope(['scope1']), 'scope1');
   });
 }

--- a/test/unit/src/utils/startup/initializer_test.dart
+++ b/test/unit/src/utils/startup/initializer_test.dart
@@ -13,6 +13,7 @@ void main() {
         urlState: 'urlState',
         clientIdParam: 'clientIdParam',
         redirectUrlParam: 'redirectUrlParam',
+        scopeParam: ['scope1', 'scope2'],
       ),
     );
 
@@ -23,6 +24,7 @@ void main() {
     expect(graph.linkedInConfiguration.frontendRedirectUrl, isNull);
     expect(graph.linkedInConfiguration.state, 'urlState');
     expect(graph.linkedInConfiguration.projection!.length, 5);
+    expect(graph.linkedInConfiguration.scope!.length, 2);
   });
 
   test('is graph created with init for AuthCodeConfig', () async {
@@ -32,6 +34,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         redirectUrlParam: 'redirectUrlParam',
         frontendRedirectUrlParam: 'frontendRedirectUrlParam',
+        scopeParam: ['scope1'],
       ),
     );
 
@@ -45,5 +48,6 @@ void main() {
     );
     expect(graph.linkedInConfiguration.projection, isNull);
     expect(graph.linkedInConfiguration.clientSecret, isNull);
+    expect(graph.linkedInConfiguration.scope!.length, 1);
   });
 }

--- a/test/unit/src/utils/startup/initializer_test.dart
+++ b/test/unit/src/utils/startup/initializer_test.dart
@@ -1,5 +1,6 @@
 import 'package:linkedin_login/src/utils/configuration.dart';
 import 'package:linkedin_login/src/utils/constants.dart';
+import 'package:linkedin_login/src/utils/scope.dart';
 import 'package:linkedin_login/src/utils/startup/graph.dart';
 import 'package:linkedin_login/src/utils/startup/initializer.dart';
 import 'package:test/test.dart';
@@ -13,7 +14,7 @@ void main() {
         urlState: 'urlState',
         clientIdParam: 'clientIdParam',
         redirectUrlParam: 'redirectUrlParam',
-        scopeParam: ['scope1', 'scope2'],
+        scopeParam: const [EmailAddressScope(), LiteProfileScope()],
       ),
     );
 
@@ -25,8 +26,10 @@ void main() {
     expect(graph.linkedInConfiguration.state, 'urlState');
     expect(graph.linkedInConfiguration.projection!.length, 5);
     expect(
-      graph.linkedInConfiguration.scope(['scope1', 'scope2']),
-      'scope1%20scope2',
+      graph.linkedInConfiguration.parseScopesToQueryParam(
+        const [EmailAddressScope(), LiteProfileScope()],
+      ),
+      'r_emailaddress%20r_liteprofile',
     );
   });
 
@@ -37,7 +40,7 @@ void main() {
         clientIdParam: 'clientIdParam',
         redirectUrlParam: 'redirectUrlParam',
         frontendRedirectUrlParam: 'frontendRedirectUrlParam',
-        scopeParam: ['scope1'],
+        scopeParam: const [EmailAddressScope()],
       ),
     );
 
@@ -51,6 +54,10 @@ void main() {
     );
     expect(graph.linkedInConfiguration.projection, isNull);
     expect(graph.linkedInConfiguration.clientSecret, isNull);
-    expect(graph.linkedInConfiguration.scope(['scope1']), 'scope1');
+    expect(
+      graph.linkedInConfiguration
+          .parseScopesToQueryParam(const [EmailAddressScope()]),
+      'r_emailaddress',
+    );
   });
 }


### PR DESCRIPTION
Adds a user configurable way to define scope when using `LinkedInUserWidget` and `LinkedInAuthCodeWidget`. This leaves the default scope as `r_emailaddress%20r_liteprofile`, but allows user to set whatever scopes they want.

This PR fixes issue mentioned in #83.

@d3xt3r2909 Let me know your feedback